### PR TITLE
Add volume control

### DIFF
--- a/TTS.gd
+++ b/TTS.gd
@@ -36,6 +36,71 @@ func _ready():
 	pause_mode = Node.PAUSE_MODE_PROCESS
 
 
+func _get_min_volume():
+	if OS.has_feature('JavaScript'):
+		return 0
+	else:
+		return 0
+
+var min_volume setget , _get_min_volume
+
+
+func _get_max_volume():
+	if OS.has_feature('JavaScript'):
+		return 1.0
+	else:
+		return 0
+
+var max_volume setget , _get_max_volume
+
+
+func _get_normal_volume():
+	if OS.has_feature('JavaScript'):
+		return 1.0
+	else:
+		return 0
+
+var normal_volume setget , _get_normal_volume
+
+var javascript_volume = self.normal_volume
+
+
+func _set_volume(volume):
+	if volume < self.min_volume:
+		volume = self.min_volume
+	elif volume > self.max_volume:
+		volume = self.max_volume
+	if OS.has_feature('JavaScript'):
+		javascript_volume = volume
+
+
+func _get_volume():
+	if OS.has_feature('JavaScript'):
+		return javascript_volume
+	else:
+		return 0
+
+
+var volume setget _set_volume, _get_volume
+
+
+func _get_volume_percentage():
+	return range_lerp(self.volume, self.min_volume, self.max_volume, 0, 100)
+
+
+func _set_volume_percentage(v):
+	self.rate = range_lerp(v, 0, 100, self.min_volume, self.max_volume)
+
+
+var volume_percentage setget _set_volume_percentage, _get_volume_percentage
+
+
+func _get_normal_volume_percentage():
+	return range_lerp(self.normal_volume, self.min_volume, self.max_volume, 0, 100)
+
+var normal_volume_percentage setget , _get_normal_volume_percentage
+
+
 func _get_min_rate():
 	if OS.has_feature('JavaScript'):
 		return 0.1
@@ -132,15 +197,16 @@ func speak(text, interrupt := true):
 	elif OS.has_feature('JavaScript'):
 		var code = (
 			"""
-            let utterance = new SpeechSynthesisUtterance("%s")
-            utterance.rate = %s
-        """
-			% [text.replace("\n", " "), javascript_rate]
+			let utterance = new SpeechSynthesisUtterance("%s")
+			utterance.rate = %s
+			utterance.volume = %s
+		"""
+			% [text.replace("\n", " "), javascript_rate, javascript_volume]
 		)
 		if interrupt:
 			code += """
-                window.speechSynthesis.cancel()
-            """
+				window.speechSynthesis.cancel()
+			"""
 		code += "window.speechSynthesis.speak(utterance)"
 		JavaScript.eval(code)
 	else:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,70 @@ impl TTS {
 
     fn register(builder: &ClassBuilder<Self>) {
         builder
+            .add_property("volume")
+            .with_getter(|this: &TTS, _| match this.0.get_volume() {
+                Ok(volume) => volume,
+                _ => 0.,
+            })
+            .with_setter(|this: &mut TTS, _, v: f32| {
+                let Features {
+                    volume: volume_supported,
+                    ..
+                } = this.0.supported_features();
+                if volume_supported {
+                    let mut v = v;
+                    if v < this.0.min_volume() {
+                        v = this.0.min_volume();
+                    } else if v > this.0.max_volume() {
+                        v = this.0.max_volume();
+                    }
+                    this.0.set_volume(v).expect("Failed to set volume");
+                }
+            })
+            .done();
+        builder
+            .add_property("min_volume")
+            .with_getter(|this: &TTS, _| {
+                let Features {
+                    volume: volume_supported,
+                    ..
+                } = this.0.supported_features();
+                if volume_supported {
+                    this.0.min_volume()
+                } else {
+                    0.
+                }
+            })
+            .done();
+        builder
+            .add_property("max_volume")
+            .with_getter(|this: &TTS, _| {
+                let Features {
+                    volume: volume_supported,
+                    ..
+                } = this.0.supported_features();
+                if volume_supported {
+                    this.0.max_volume()
+                } else {
+                    0.
+                }
+            })
+            .done();
+        builder
+            .add_property("normal_volume")
+            .with_getter(|this: &TTS, _| {
+                let Features {
+                    volume: volume_supported,
+                    ..
+                } = this.0.supported_features();
+                if volume_supported {
+                    this.0.normal_volume()
+                } else {
+                    0.
+                }
+            })
+            .done();
+        builder
             .add_property("rate")
             .with_getter(|this: &TTS, _| match this.0.get_rate() {
                 Ok(rate) => rate,

--- a/src/main/java/games/lightsout/godot/tts/TTS.java
+++ b/src/main/java/games/lightsout/godot/tts/TTS.java
@@ -18,6 +18,7 @@ import android.view.accessibility.AccessibilityManager;
 public class TTS extends GodotPlugin implements TextToSpeech.OnInitListener {
     private TextToSpeech tts = null;
 
+    private float volume = 1f;
     private float rate = 1f;
 
     private Integer utteranceId = 0;
@@ -34,6 +35,15 @@ public class TTS extends GodotPlugin implements TextToSpeech.OnInitListener {
 
     public void stop() {
         tts.stop();
+    }
+
+    public float get_volume() {
+        return this.volume;
+    }
+
+    public void set_volume(float volume) {
+        this.volume = volume;
+        tts.Engine.KEY_PARAM_VOLUME = volume;
     }
 
     public float get_rate() {


### PR DESCRIPTION
Adds volume control for text to speech playback. The variable `volume` can be set to values between 0 and 1 (or as a percentage from 0 to 100).

Resolves https://github.com/lightsoutgames/godot-tts/issues/6

I've successfully tested this in browser and also in the Godot editor. I've only been able to test on Windows 10. I haven't been able to test this on Mac OS, Linux, or Android. Android in particular gave me some trouble - despite trying for quite a while, I wasn't able to successfully build the code at all (not even from master, so I don't think this is to do with my changes). This is my first time working with a Godot addon at all so this is the best I can do for right now.